### PR TITLE
example hcl minor cleanup

### DIFF
--- a/example/redis-cluster.hcl
+++ b/example/redis-cluster.hcl
@@ -199,6 +199,7 @@ job "redis-cluster" {
       }
       service {
         name = var.await-service-name
+        port = "db"
         check {
           name     = "attache:tcp-alive"
           type     = "tcp"

--- a/example/redis-cluster.hcl
+++ b/example/redis-cluster.hcl
@@ -199,14 +199,6 @@ job "redis-cluster" {
       }
       service {
         name = var.await-service-name
-        port = "db"
-        check {
-          name     = "db:tcp-alive"
-          type     = "tcp"
-          port     = "db"
-          interval = "3s"
-          timeout  = "2s"
-        }
         check {
           name     = "attache:tcp-alive"
           type     = "tcp"


### PR DESCRIPTION
The attache-control task does not need to advertise the redis-server's port, nor does it need to use a tcp liveness check on the redis-server. That's the redis-server's task's job.