### PR TITLE
control: Improve node classification

### DIFF
--- a/cmd/attache-control/main.go
+++ b/cmd/attache-control/main.go
@@ -153,7 +153,14 @@ func (l *leader) joinOrCreateRedisCluster() error {
 		return nil
 	}
 
-	// This should never happen as long as the job and scaling opts match.
+	clusterNodesCount := len(primaryNodesInCluster) + len(replicaNodesInCluster)
+	if l.scalingOpts.NodesMissing(clusterNodesCount) == 0 {
+		// This will only happen when the Nomad job is scaled without a
+		// corresponding change to the scaling opts in Consul.
+		return fmt.Errorf("%s Nomad group count was scaled without a corresponding change to scaling opts", l.RedisOpts.NodeAddr)
+	}
+
+	// This should never happen.
 	return fmt.Errorf("%s couldn't be added to an existing cluster", l.RedisOpts.NodeAddr)
 }
 


### PR DESCRIPTION
- Make classification in `NodeIsNew()` less overfit.
- Return a clear error when the scaling values in Nomad and Consul are
  mismatched

Resolves #36 
Resolves #11